### PR TITLE
SSH support for SVN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.itemis</groupId>
     <artifactId>org-parent</artifactId>
-    <version>1</version>
+    <version>3</version>
   </parent>
 
   <groupId>com.itemis.maven.plugins</groupId>
@@ -39,11 +39,11 @@
 
   <properties>
     <version.guava>19.0</version.guava>
-    <version.java>1.6</version.java>
+    <version.java>1.8</version.java>
     <version.junit>4.12</version.junit>
     <version.junit-dataprovider>1.10.3</version.junit-dataprovider>
-    <version.unleash-scm-provider-api>2.4.1</version.unleash-scm-provider-api>
-    <version.svnkit>1.8.12</version.svnkit>
+    <version.unleash-scm-provider-api>2.9.3</version.unleash-scm-provider-api>
+    <version.svnkit>1.9.3</version.svnkit>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
I drafted a first version for SSH support for SVN here. Works for me both with public key as well as with username / password authentication. 

I only see one issue here so far: SVNKits DefaultSVNAuthenticationManager does not accept a private key directly (although some levels deeper underlying SVNSSHAuthentication would) but only the reference to a private key file. I misused the property scmSshPrivateKeyEnvVar to point to an environment variable containing a reference to the private key file. This might lead to problems in the Jenkins use case.

Generally I could drive this further in two directions:
- Add another configuration property for the private key file
- Analyze SVNKit or adapt SVNKit to pass the private key from the property file in 